### PR TITLE
[CI] Set the CI timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
         with:
@@ -17,6 +18,7 @@ jobs:
       - run: docker-compose run --rm lint
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The default GitHub timeout (6 hours) is far too long.