### PR TITLE
Rename the plugin to `external-buildkite-buildkite-plugin`, so that users can use it as `JuliaCI/external-buildkite`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# External Buildkite Plugin
+# `external-buildkite` Buildkite Plugin
 
 [![Continuous Integration (CI)][ci-img]][ci-url]
 
-[ci-img]: https://github.com/JuliaCI/external-buildkite-plugin/actions/workflows/ci.yml/badge.svg "Continuous Integration (CI)"
-[ci-url]: https://github.com/JuliaCI/external-buildkite-plugin/actions/workflows/ci.yml
+[ci-img]: https://github.com/JuliaCI/external-buildkite-buildkite-plugin/actions/workflows/ci.yml/badge.svg "Continuous Integration (CI)"
+[ci-url]: https://github.com/JuliaCI/external-buildkite-buildkite-plugin/actions/workflows/ci.yml
 
 Download Buildkite configuration files from an external repository.
 
@@ -14,7 +14,7 @@ Add the following to your `pipeline.yml`:
 ```yml
 steps:
   - plugins:
-    - JuliaCI/external#v1.0:
+    - JuliaCI/external-buildkite#v1.0:
         version_file: 'buildkite.version'
         external_repo: 'https://github.com/JuliaCI/julia-buildkite.git'
         folder: '.buildkite'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   lint:
     image: buildkite/plugin-linter:latest
-    command: ['--id', 'JuliaCI/external']
+    command: ['--id', 'JuliaCI/external-buildkite']
     volumes:
       - ".:/plugin:ro"
   test:

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,11 +2,11 @@
 
 set -Eeuo pipefail
 
-echo "--- Print the \`external\` plugin inputs:"
+echo "--- Print the \`external-buildkite\` plugin inputs:"
 
-BK_VERSION_FILE="${BUILDKITE_PLUGIN_EXTERNAL_VERSION_FILE:?}"
-BK_EXTERNAL_REPO="${BUILDKITE_PLUGIN_EXTERNAL_EXTERNAL_REPO:?}"
-BK_FOLDER_NAME="${BUILDKITE_PLUGIN_EXTERNAL_FOLDER:?}"
+BK_VERSION_FILE="${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION_FILE:?}"
+BK_EXTERNAL_REPO="${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_EXTERNAL_REPO:?}"
+BK_FOLDER_NAME="${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER:?}"
 
 echo "The Buildkite config version is located in the following file: ${BK_VERSION_FILE:?}"
 echo "The Buildkite config files will be downloaded from the following repository: ${BK_EXTERNAL_REPO:?}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: External
+name: External Buildkite
 description: Download Buildkite configuration files from an external repository
 author: https://github.com/JuliaCI
 requirements: [git]

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -8,20 +8,20 @@ load "${BATS_PATH:?}/load.bash"
 @test "Integration test" {
     TEMPORARY_DIRECTORY=$(mktemp -d)
 
-    export BUILDKITE_PLUGIN_EXTERNAL_VERSION_FILE="${TEMPORARY_DIRECTORY:?}/buildkite.version"
-    export BUILDKITE_PLUGIN_EXTERNAL_EXTERNAL_REPO="https://github.com/JuliaLang/julia.git"
-    export BUILDKITE_PLUGIN_EXTERNAL_FOLDER="${TEMPORARY_DIRECTORY:?}/.buildkite"
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION_FILE="${TEMPORARY_DIRECTORY:?}/buildkite.version"
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_EXTERNAL_REPO="https://github.com/JuliaLang/julia.git"
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER="${TEMPORARY_DIRECTORY:?}/.buildkite"
 
-    run bash -c "rm -rf ${BUILDKITE_PLUGIN_EXTERNAL_VERSION_FILE:?}"
-    run bash -c "echo d08b05df6f01cf4ec6e4c28ad94cedda76cc62e8 > ${BUILDKITE_PLUGIN_EXTERNAL_VERSION_FILE:?}"
+    run bash -c "rm -rf ${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION_FILE:?}"
+    run bash -c "echo d08b05df6f01cf4ec6e4c28ad94cedda76cc62e8 > ${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION_FILE:?}"
 
     run "${PWD:?}/hooks/post-checkout"
 
     assert_success
 
-    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_VERSION_FILE:?}
-    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_FOLDER}/README.md
-    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_FOLDER}/stdlib/Pkg.version
+    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION_FILE:?}
+    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER}/README.md
+    assert_file_exist ${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER}/stdlib/Pkg.version
 
     assert_output --partial "The Buildkite config version is: d08b05df6f01cf4ec6e4c28ad94cedda76cc62e8"
     assert_output --partial "commit d08b05df6f01cf4ec6e4c28ad94cedda76cc62e8"


### PR DESCRIPTION
Fixes #4