### PR TITLE
Clear out a pre-existing `.buildkite` folder before attempting to check out into it

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -19,6 +19,8 @@ INPUT_VERSION="$(get_meta_env_value VERSION)"
 
 
 # Clone external repo to the local path:
+rm -rf "${INPUT_FOLDER}"
+mkdir -p "$(dirname ${INPUT_FOLDER})"
 git clone "${INPUT_REPO_URL}" "${INPUT_FOLDER}"
 
 # Resolve the version, now that we have all the files locally:

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -95,3 +95,15 @@ function test_known_checkout() {
     assert [ $(buildkite-agent meta-data get BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION) == "test-anchor" ]
     test_known_checkout
 }
+
+@test "pre-existing target folder" {
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_REPO_URL="https://github.com/JuliaCI/external-buildkite-buildkite-plugin"
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER=".buildkite"
+    export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION="./.buildkite/version"
+
+    # Create a `.buildkite` folder that already contains some stuff
+    mkdir -p "${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER}"
+    echo "test-anchor" > "${BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION}"
+
+    test_known_checkout
+}


### PR DESCRIPTION
Since we will have a `.buildkite` folder in the main Julia repository, most likely.