### PR TITLE
Allow comments within `version` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ steps:
 ```
 
 Note that `version` can be a gitsha, a gitref (e.g. `master`), or the path to a file that contains within it a gitsha or gitref.
-If you opt to use a file for `version`, you must specify its path starting with `./` to disambiguate it from an arbitrary gitref.
+If you opt to use a file for `version`, you must specify its path starting with `./` or `/` to disambiguate it from an arbitrary gitref.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -37,13 +37,15 @@ function resolve_version() {
         return 0
     fi
 
-    # Are we a file?  We only accept files that start with `./`, to disambiguate
+    # Are we a file?  We only accept files that start with `./` or `/`, to disambiguate
     # files from valid git tags that look like files.  We also check to make sure
     # that reading the file results in only a single word (a gitsha or gitref)
-    if [[ "${VERSION}" == "./"* ]]; then
-        local VERSION_CONTENTS="$(cat "${VERSION}" 2>/dev/null)"
-        if [[ "$(wc -w <<< "${VERSION_CONTENTS}" | xargs)" -ne "1" ]]; then
-            die "The ${VERSION} file must contain exactly 1 word!"
+    if [[ "${VERSION}" == "./"* ]] || [[ "${VERSION}" == "/"* ]]; then
+        # Strip out empty lines and comments
+        local VERSION_CONTENTS="$(cat "${VERSION}" 2>/dev/null | grep -o '^[^#]*')"
+        NUM_VERSION_WORDS="$(wc -w <<< "${VERSION_CONTENTS}" | xargs)"
+        if [[ "${NUM_VERSION_WORDS}" -ne "1" ]]; then
+            die "The ${VERSION} file must contain exactly 1 word, but we counted '${NUM_VERSION_WORDS}'!"
         fi
 
         # If the version_CONTENTS file contains a gitsha, excellent, we're done

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -80,7 +80,8 @@ function test_known_checkout() {
     export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER="${TEMPORARY_DIRECTORY:?}/.buildkite"
     export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION="./version"
 
-    echo "test-anchor" > ./version
+    echo "# This is a comment and should be ignored" > ./version
+    echo "test-anchor" >> ./version
     test_known_checkout
 }
 


### PR DESCRIPTION
Also allow specifying a version file by absolute path as well as relative.