### PR TITLE
Try fetching without `origin/` prefix

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -20,7 +20,7 @@ INPUT_VERSION="$(get_meta_env_value VERSION)"
 
 # Clone external repo to the local path
 git clone "${INPUT_REPO_URL}" "${INPUT_FOLDER}"
-git -C "${INPUT_FOLDER}" fetch origin 'refs/*:refs/*'
+git -C "${INPUT_FOLDER}" fetch -u origin 'refs/*:refs/*'
 
 # Resolve the version, now that we have all the files locally:
 RESOLVED_VERSION="$(resolve_version "${INPUT_VERSION}" "${INPUT_FOLDER}")"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -20,7 +20,7 @@ INPUT_VERSION="$(get_meta_env_value VERSION)"
 
 # Clone external repo to the local path
 git clone "${INPUT_REPO_URL}" "${INPUT_FOLDER}"
-git -C "${INPUT_FOLDER}" fetch origin 'refs/*:refs/origin/*'
+git -C "${INPUT_FOLDER}" fetch origin 'refs/*:refs/*'
 
 # Resolve the version, now that we have all the files locally:
 RESOLVED_VERSION="$(resolve_version "${INPUT_VERSION}" "${INPUT_FOLDER}")"

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -75,13 +75,13 @@ function test_known_checkout() {
     test_known_checkout
 }
 
-@test "File gitref" {
+@test "File branch" {
     export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_REPO_URL="https://github.com/JuliaCI/external-buildkite-buildkite-plugin"
     export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_FOLDER="${TEMPORARY_DIRECTORY:?}/.buildkite"
     export BUILDKITE_PLUGIN_EXTERNAL_BUILDKITE_VERSION="./version"
 
     echo "# This is a comment and should be ignored" > ./version
-    echo "test-anchor" >> ./version
+    echo "test-branch" >> ./version
     test_known_checkout
 }
 


### PR DESCRIPTION
This ensures that all remote branches are automatically tracked, so that we can put `branch` in our version file, instead of `remotes/origin/branch`